### PR TITLE
Made the listener use the configured type field name

### DIFF
--- a/Form/EventListener/ResizePolyFormListener.php
+++ b/Form/EventListener/ResizePolyFormListener.php
@@ -38,13 +38,22 @@ class ResizePolyFormListener extends ResizeFormListener
     protected $classMap = array();
 
     /**
+     * Name of the hidden field identifying the type
+     *
+     * @var string
+     */
+    protected $typeFieldName;
+
+    /**
      * @param array<FormInterface> $prototypes
      * @param array $options
      * @param bool $allowAdd
      * @param bool $allowDelete
+     * @param string $typeFieldName
      */
-    public function __construct(array $prototypes, array $options = array(), $allowAdd = false, $allowDelete = false)
+    public function __construct(array $prototypes, array $options = array(), $allowAdd = false, $allowDelete = false, $typeFieldName = '_type')
     {
+        $this->typeFieldName = $typeFieldName;
         $defaultType = null;
 
         foreach ($prototypes as $prototype) {
@@ -93,11 +102,11 @@ class ResizePolyFormListener extends ResizeFormListener
      */
     protected function getTypeForData(array $data)
     {
-        if (!array_key_exists('_type', $data) or !array_key_exists($data['_type'], $this->typeMap)) {
+        if (!array_key_exists($this->typeFieldName, $data) || !array_key_exists($data[$this->typeFieldName], $this->typeMap)) {
             throw new \InvalidArgumentException('Unable to determine the Type for given data');
         }
 
-        return $this->typeMap[$data['_type']];
+        return $this->typeMap[$data[$this->typeFieldName]];
     }
 
     public function preSetData(FormEvent $event)

--- a/Form/Type/PolyCollectionType.php
+++ b/Form/Type/PolyCollectionType.php
@@ -44,7 +44,8 @@ class PolyCollectionType extends AbstractType
             $prototypes,
             $options['options'],
             $options['allow_add'],
-            $options['allow_delete']
+            $options['allow_delete'],
+            $options['type_name']
         );
 
         $builder->addEventSubscriber($resizeListener);

--- a/Tests/PolyCollection/PolyCollectionTypeTest.php
+++ b/Tests/PolyCollection/PolyCollectionTypeTest.php
@@ -147,6 +147,47 @@ class PolyCollectionTypeTest extends TypeTestCase
         $this->assertEquals('Car', $form[1]->getData()->text2);
     }
 
+    public function testResizedWithCustomTypeField()
+    {
+        $form = $this->factory->create('infinite_form_polycollection', null, array(
+            'types' => array(
+                'abstract_type',
+                'first_type',
+                'second_type'
+            ),
+            'type_name' => '_type_id',
+            'allow_add' => true
+        ));
+
+        $form->setData(array(
+            new AbstractModel('Green'),
+        ));
+        $form->bind(array(
+            array(
+                '_type_id' => 'abstract_type',
+                'text' => 'Green'
+            ),
+            array(
+                '_type_id' => 'first_type',
+                'text' => 'Red',
+                'text2' => 'Car'
+            )
+        ));
+
+        $this->assertTrue($form->has('0'));
+        $this->assertTrue($form->has('1'));
+        $this->assertInstanceOf(
+            'Infinite\\FormBundle\\Tests\\PolyCollection\\Model\\AbstractModel',
+            $form[0]->getData()
+        );
+        $this->assertInstanceOf(
+            'Infinite\\FormBundle\\Tests\\PolyCollection\\Model\\First',
+            $form[1]->getData()
+        );
+        $this->assertEquals('Red', $form[1]->getData()->text);
+        $this->assertEquals('Car', $form[1]->getData()->text2);
+    }
+
     public function testNotResizedIfBoundWithExtraData()
     {
         $form = $this->factory->create('infinite_form_polycollection', null, array(


### PR DESCRIPTION
Hardcoding the name in it makes the type option useless.
