### PR TITLE
Make PolyCollection extend collection form type

### DIFF
--- a/Form/Type/PolyCollectionType.php
+++ b/Form/Type/PolyCollectionType.php
@@ -163,7 +163,14 @@ class PolyCollectionType extends AbstractType
             'options' => $optionsNormalizer,
         ));
     }
-
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent() {
+        return 'collection';
+    }
+    
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
Since the polycollection is, in essence, looks and works very similarly to the original collection type, would it make sense to extend the original collection type? Most form templates will already extend the collection type to add the buttons etc. and by extending the original collection, the polycollection can take advantage of this without duplication. Especially as a lot of the theme bundles (e.g. Mopa Bootstrap) have explicit checks and special handling for collections, it means currently most people will have to duplicate this styling themselves for the polycollection. Any thoughts?
