### PR TITLE
Entity property can be used as index for PolyCollection entries

### DIFF
--- a/Form/EventListener/ResizePolyFormListener.php
+++ b/Form/EventListener/ResizePolyFormListener.php
@@ -9,7 +9,6 @@
 
 namespace Infinite\FormBundle\Form\EventListener;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\PersistentCollection;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;

--- a/Form/EventListener/ResizePolyFormListener.php
+++ b/Form/EventListener/ResizePolyFormListener.php
@@ -146,7 +146,7 @@ class ResizePolyFormListener extends ResizeFormListener
             $form->remove($name);
         }
 
-        // Then add all rows again in the correct order
+        // Then add all rows again in the correct order for the incoming data
         foreach ($data as $name => $value) {
             $type = $this->getTypeForObject($value);
             $form->add($name, $type, array_replace(array(

--- a/Form/Type/PolyCollectionType.php
+++ b/Form/Type/PolyCollectionType.php
@@ -46,7 +46,8 @@ class PolyCollectionType extends AbstractType
             $options['options'],
             $options['allow_add'],
             $options['allow_delete'],
-            $options['type_name']
+            $options['type_name'],
+            $options['index_property']
         );
 
         $builder->addEventSubscriber($resizeListener);
@@ -149,6 +150,7 @@ class PolyCollectionType extends AbstractType
             'prototype_name' => '__name__',
             'type_name'      => '_type',
             'options'        => array(),
+            'index_property' => null,
         ));
 
         $resolver->setRequired(array(

--- a/Tests/PolyCollection/Model/AbstractModel.php
+++ b/Tests/PolyCollection/Model/AbstractModel.php
@@ -4,10 +4,14 @@ namespace Infinite\FormBundle\Tests\PolyCollection\Model;
 
 class AbstractModel
 {
+    public $id;
+
     public $text;
 
-    public function __construct($text = null)
+    public function __construct($text = null, $id = null)
     {
+        $this->id = $id;
+
         $this->text = $text;
     }
 }

--- a/Tests/PolyCollection/Model/First.php
+++ b/Tests/PolyCollection/Model/First.php
@@ -6,9 +6,9 @@ class First extends AbstractModel
 {
     public $text2;
 
-    public function __construct($text = null, $text2 = null)
+    public function __construct($text = null, $text2 = null, $id = null)
     {
-        parent::__construct($text);
+        parent::__construct($text, $id);
 
         $this->text2 = $text2;
     }

--- a/Tests/PolyCollection/Model/Second.php
+++ b/Tests/PolyCollection/Model/Second.php
@@ -6,9 +6,9 @@ class Second extends AbstractModel
 {
     public $checked;
 
-    public function __construct($text = null, $checked = false)
+    public function __construct($text = null, $checked = false, $id = null)
     {
-        parent::__construct($text);
+        parent::__construct($text, $id);
 
         $this->checked = $checked;
     }

--- a/Tests/PolyCollection/PolyCollectionTypeTest.php
+++ b/Tests/PolyCollection/PolyCollectionTypeTest.php
@@ -432,6 +432,46 @@ class PolyCollectionTypeTest extends TypeTestCase
         );
     }
 
+    public function testReorderedIfBoundWithShuffledDataAndAllowMatchWithEntityIndexProperty()
+    {
+        $form = $this->factory->create('infinite_form_polycollection', null, array(
+                'types' => array(
+                    'abstract_type',
+                    'first_type',
+                    'second_type'
+                ),
+                'allow_add' => true,
+                'index_property' => 'id'
+            ));
+        $form->setData(array(
+                new AbstractModel('Green', 1),
+                new Second('Blue', false, 2)
+            ));
+        $form->bind(array(
+                array(
+                    '_type' => 'second_type',
+                    'checked' => 'true',
+                    'id'=>2
+                ),
+                array(
+                    '_type' => 'abstract_type',
+                    'text' => 'Green',
+                    'id'=>1
+                )
+            ));
+
+        $this->assertTrue($form->has('0'));
+        $this->assertTrue($form->has('1'));
+        $this->assertInstanceOf(
+            'Infinite\\FormBundle\\Tests\\PolyCollection\\Model\\AbstractModel',
+            $form[0]->getData()
+        );
+        $this->assertInstanceOf(
+            'Infinite\\FormBundle\\Tests\\PolyCollection\\Model\\Second',
+            $form[1]->getData()
+        );
+    }
+
     public function testContainsNoChildByDefault()
     {
         $form = $this->factory->create('infinite_form_polycollection', null, array(

--- a/Tests/PolyCollection/PolyCollectionTypeTest.php
+++ b/Tests/PolyCollection/PolyCollectionTypeTest.php
@@ -241,9 +241,8 @@ class PolyCollectionTypeTest extends TypeTestCase
                 'text' => 'Green'
             ),
             array(
-                '_type' => 'first_type',
-                'text' => 'Red',
-                'text2' => 'Car'
+                '_type' => 'second_type',
+                'checked' => 'true'
             )
         ));
 
@@ -255,7 +254,7 @@ class PolyCollectionTypeTest extends TypeTestCase
             $form[0]->getData()
         );
         $this->assertInstanceOf(
-            'Infinite\\FormBundle\\Tests\\PolyCollection\\Model\\First',
+            'Infinite\\FormBundle\\Tests\\PolyCollection\\Model\\Second',
             $form[1]->getData()
         );
     }

--- a/Tests/PolyCollection/PolyCollectionTypeTest.php
+++ b/Tests/PolyCollection/PolyCollectionTypeTest.php
@@ -416,12 +416,14 @@ class PolyCollectionTypeTest extends TypeTestCase
                 ),
                 array(
                     '_type' => 'second_type',
+                    'text' => 'Blue',
                     'checked' => 'true'
                 )
             ));
 
         $this->assertTrue($form->has('0'));
         $this->assertTrue($form->has('1'));
+        $this->assertEquals(2, $form->count());
         $this->assertInstanceOf(
             'Infinite\\FormBundle\\Tests\\PolyCollection\\Model\\AbstractModel',
             $form[0]->getData()

--- a/Tests/PolyCollection/PolyCollectionTypeTest.php
+++ b/Tests/PolyCollection/PolyCollectionTypeTest.php
@@ -236,26 +236,26 @@ class PolyCollectionTypeTest extends TypeTestCase
             new Second('Blue', true)
         ));
         $form->bind(array(
-            array(
+            0=>array(
                 '_type' => 'abstract_type',
                 'text' => 'Green'
             ),
-            array(
+            2=>array(
                 '_type' => 'second_type',
                 'checked' => 'true'
             )
         ));
 
         $this->assertTrue($form->has('0'));
-        $this->assertTrue($form->has('1'));
-        $this->assertFalse($form->has('2'));
+        $this->assertFalse($form->has('1'));
+        $this->assertTrue($form->has('2'));
         $this->assertInstanceOf(
             'Infinite\\FormBundle\\Tests\\PolyCollection\\Model\\AbstractModel',
             $form[0]->getData()
         );
         $this->assertInstanceOf(
             'Infinite\\FormBundle\\Tests\\PolyCollection\\Model\\Second',
-            $form[1]->getData()
+            $form[2]->getData()
         );
     }
 
@@ -350,6 +350,86 @@ class PolyCollectionTypeTest extends TypeTestCase
         $this->assertFalse(isset($form[2]));
         $this->assertEquals('Orange', $form[0]->getData()->text);
         $this->assertEquals(20, $form[0]->getConfig()->getOption('max_length'));
+    }
+
+    public function testResizedDownIfBoundWithMissingDataAndAllowDeleteWithEntityIndexProperty()
+    {
+        $form = $this->factory->create('infinite_form_polycollection', null, array(
+                'types' => array(
+                    'abstract_type',
+                    'first_type',
+                    'second_type'
+                ),
+                'allow_delete' => true,
+                'index_property' => 'id'
+            ));
+        $form->setData(array(
+                new AbstractModel('Green', 1),
+                new First('Red', 'Car', 2),
+                new Second('Blue', true, 3)
+            ));
+        $form->bind(array(
+                array(
+                    '_type' => 'abstract_type',
+                    'text' => 'Green',
+                    'id'=>1
+                ),
+                array(
+                    '_type' => 'second_type',
+                    'checked' => 'true',
+                    'id'=>3
+                )
+            ));
+
+        $this->assertTrue($form->has('0'));
+        $this->assertFalse($form->has('1'));
+        $this->assertTrue($form->has('2'));
+        $this->assertInstanceOf(
+            'Infinite\\FormBundle\\Tests\\PolyCollection\\Model\\AbstractModel',
+            $form[0]->getData()
+        );
+        $this->assertInstanceOf(
+            'Infinite\\FormBundle\\Tests\\PolyCollection\\Model\\Second',
+            $form[2]->getData()
+        );
+    }
+
+    public function testResizedUpIfBoundWithExtraDataAndAllowAddWithEntityIndexPropertyMissing()
+    {
+        $form = $this->factory->create('infinite_form_polycollection', null, array(
+                'types' => array(
+                    'abstract_type',
+                    'first_type',
+                    'second_type'
+                ),
+                'allow_add' => true,
+                'index_property' => 'id'
+            ));
+        $form->setData(array(
+                new AbstractModel('Green', 1),
+            ));
+        $form->bind(array(
+                array(
+                    '_type' => 'abstract_type',
+                    'text' => 'Green',
+                    'id'=>1
+                ),
+                array(
+                    '_type' => 'second_type',
+                    'checked' => 'true'
+                )
+            ));
+
+        $this->assertTrue($form->has('0'));
+        $this->assertTrue($form->has('1'));
+        $this->assertInstanceOf(
+            'Infinite\\FormBundle\\Tests\\PolyCollection\\Model\\AbstractModel',
+            $form[0]->getData()
+        );
+        $this->assertInstanceOf(
+            'Infinite\\FormBundle\\Tests\\PolyCollection\\Model\\Second',
+            $form[1]->getData()
+        );
     }
 
     public function testContainsNoChildByDefault()

--- a/Tests/PolyCollection/Type/AbstractType.php
+++ b/Tests/PolyCollection/Type/AbstractType.php
@@ -12,6 +12,10 @@ class AbstractType extends BaseType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $builder->add('id', 'number', array(
+            'required'=>false,
+        ));
+
         $builder->add('text', 'text');
 
         $builder->add('_type', 'hidden', array(

--- a/Tests/PolyCollection/Type/AbstractType.php
+++ b/Tests/PolyCollection/Type/AbstractType.php
@@ -12,9 +12,7 @@ class AbstractType extends BaseType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('id', 'number', array(
-            'required'=>false,
-        ));
+        $builder->add('id', 'number');
 
         $builder->add('text', 'text');
 


### PR DESCRIPTION
We had a use case where we were using PolyCollection, but the data submitted by a JSON request would have certain items removed, and other items added. The order of the array could deviate, and the JSON data could not be changed to persist the length or keys of the array passed back to PolyCollection. This resulted in the PolyCollection form, the original list of items, and the submitted data becoming out of sync, and producing form errors.

This PR enables specifying an index_property, such as "id", rather than rely on the size/order of the PolyCollection array to infer the identity of submitted values, which is quite unreliable.

Where an index_property is provided for PolyCollection, the submitted form data is restructured to match the expected array order. This was the only way I could find to do it without Forms choking on "Expected X entity" errors.

There is an additional change to the unit test testResizedDownIfBoundWithMissingDataAndAllowDeleteWithEntityIndexProperty to highlight that when using PolyCollection, the default identifier between items is simply the array key.