### PR TITLE
Add configureOptions method to form types for SF 2.7

### DIFF
--- a/Form/Type/AttachmentType.php
+++ b/Form/Type/AttachmentType.php
@@ -10,6 +10,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class AttachmentType extends AbstractType
@@ -57,11 +58,17 @@ class AttachmentType extends AbstractType
         return 'infinite_form_attachment';
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setRequired(array('class'));
         $resolver->setDefaults(array(
             'secret' => $this->defaultSecret,
         ));
+    }
+
+    // BC for SF < 2.7
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
     }
 }

--- a/Form/Type/CheckboxGridType.php
+++ b/Form/Type/CheckboxGridType.php
@@ -14,6 +14,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -54,7 +55,7 @@ class CheckboxGridType extends AbstractType
         return 'infinite_form_checkbox_grid';
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'class' => null,
@@ -67,5 +68,11 @@ class CheckboxGridType extends AbstractType
             'y_choice_list',
             'y_path',
         ));
+    }
+    
+    // BC for SF < 2.7
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
     }
 }

--- a/Form/Type/CheckboxRowType.php
+++ b/Form/Type/CheckboxRowType.php
@@ -14,6 +14,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class CheckboxRowType extends AbstractType
@@ -34,12 +35,18 @@ class CheckboxRowType extends AbstractType
         return 'infinite_form_checkbox_row';
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'cell_filter' => null,
             'choice_list' => null,
             'row'         => null,
         ));
+    }
+    
+    // BC for SF < 2.7
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
     }
 }

--- a/Form/Type/EntityCheckboxGridType.php
+++ b/Form/Type/EntityCheckboxGridType.php
@@ -15,6 +15,7 @@ use Symfony\Bridge\Doctrine\Form\ChoiceList\ORMQueryBuilderLoader;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -39,7 +40,24 @@ class EntityCheckboxGridType extends AbstractType
         return 'infinite_form_checkbox_grid';
     }
 
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $this->internalConfigureOptions($resolver);
+        
+        $resolver->setNormalizer('em', $em);
+    }
+
+    // BC for SF < 2.7
     public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->internalConfigureOptions($resolver);
+        
+        $resolver->setNormalizers(array(
+            'em' => $em,
+        ));
+    }
+    
+    private function internalConfigureOptions(OptionsResolver $resolver)
     {
         $registry = $this->registry; // for closures
 
@@ -128,10 +146,6 @@ class EntityCheckboxGridType extends AbstractType
             'class',
             'x_path',
             'y_path',
-        ));
-
-        $resolver->setNormalizers(array(
-            'em' => $em,
         ));
     }
 }

--- a/Form/Type/EntityCheckboxGridType.php
+++ b/Form/Type/EntityCheckboxGridType.php
@@ -44,7 +44,7 @@ class EntityCheckboxGridType extends AbstractType
     {
         $this->internalConfigureOptions($resolver);
         
-        $resolver->setNormalizer('em', $em);
+        $resolver->setNormalizer('em', $this->getEntityManagerNormalizer());
     }
 
     // BC for SF < 2.7
@@ -53,14 +53,12 @@ class EntityCheckboxGridType extends AbstractType
         $this->internalConfigureOptions($resolver);
         
         $resolver->setNormalizers(array(
-            'em' => $em,
+            'em' => $this->getEntityManagerNormalizer(),
         ));
     }
     
     private function internalConfigureOptions(OptionsResolver $resolver)
     {
-        $registry = $this->registry; // for closures
-
         // X Axis defaults
         $defaultXClass = function (Options $options) {
             /** @var $em \Doctrine\ORM\EntityManager */
@@ -109,21 +107,6 @@ class EntityCheckboxGridType extends AbstractType
             );
         };
 
-        // Entity manager 'normaliser' - turns an entity manager name into an entity manager instance
-        $em = function (Options $options, $emName) use ($registry) {
-            if ($emName !== null) {
-                return $registry->getManager($emName);
-            }
-
-            $em = $registry->getManagerForClass($options['class']);
-
-            if ($em === null) {
-                throw new InvalidOptionsException(sprintf('"%s" is not a Doctrine entity', $options['class']));
-            }
-
-            return $em;
-        };
-
         $resolver->setDefaults(array(
             'em'              => null,
 
@@ -147,5 +130,25 @@ class EntityCheckboxGridType extends AbstractType
             'x_path',
             'y_path',
         ));
+    }
+    
+    private function getEntityManagerNormalizer()
+    {
+        $registry = $this->registry; // for closures
+
+        // Entity manager 'normaliser' - turns an entity manager name into an entity manager instance
+        return function (Options $options, $emName) use ($registry) {
+            if ($emName !== null) {
+                return $registry->getManager($emName);
+            }
+
+            $em = $registry->getManagerForClass($options['class']);
+
+            if ($em === null) {
+                throw new InvalidOptionsException(sprintf('"%s" is not a Doctrine entity', $options['class']));
+            }
+
+            return $em;
+        };
     }
 }

--- a/Form/Type/EntitySearchType.php
+++ b/Form/Type/EntitySearchType.php
@@ -7,6 +7,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class EntitySearchType extends AbstractType
@@ -36,7 +37,7 @@ class EntitySearchType extends AbstractType
         $view->vars['search_route'] = $form->getConfig()->getAttribute('search_route');
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'allow_not_found' => false,
@@ -49,6 +50,12 @@ class EntitySearchType extends AbstractType
         $resolver->setRequired(array(
             'class'
         ));
+    }
+    
+    // BC for SF < 2.7
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
     }
 
     public function getName()

--- a/Form/Type/PolyCollectionType.php
+++ b/Form/Type/PolyCollectionType.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -130,18 +131,52 @@ class PolyCollectionType extends AbstractType
             }
         }
     }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'infinite_form_polycollection';
+    }
 
     /**
      * {@inheritdoc}
      */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $this->internalConfigureOptions($resolver);
+        
+        $resolver->setAllowedTypes('types', 'array');
+        
+        $resolver->setNormalizer('options', $this->getOptionsNormalizer());
+    }
+    
+    // BC for SF < 2.7
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        $optionsNormalizer = function (Options $options, $value) {
+        $this->internalConfigureOptions($resolver);
+        
+        $resolver->setAllowedTypes(array(
+            'types' => 'array'
+        ));
+        
+        $resolver->setNormalizers(array(
+            'options' => $this->getOptionsNormalizer(),
+        ));
+    }
+    
+    private function getOptionsNormalizer()
+    {
+        return function (Options $options, $value) {
             $value['block_name'] = 'entry';
 
             return $value;
         };
-        
+    }
+    
+    private function internalConfigureOptions(OptionsResolverInterface $resolver)
+    {
         $resolver->setDefaults(array(
             'allow_add'      => false,
             'allow_delete'   => false,
@@ -154,21 +189,5 @@ class PolyCollectionType extends AbstractType
         $resolver->setRequired(array(
             'types'
         ));
-
-        $resolver->setAllowedTypes(array(
-            'types' => 'array'
-        ));
-        
-        $resolver->setNormalizers(array(
-            'options' => $optionsNormalizer,
-        ));
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'infinite_form_polycollection';
     }
 }


### PR DESCRIPTION
These changes remove the deprecation warnings for SF 2.7+

Solution is same as in other bundles (like FOSUserBundle), where both `configureOptions` and `setDefaultOptions` methods are provided.
