### PR TITLE
Fix setDefaultOptions method in form types for SF 2.6+ forward compatibility

### DIFF
--- a/Form/Type/EntityCheckboxGridType.php
+++ b/Form/Type/EntityCheckboxGridType.php
@@ -115,7 +115,8 @@ class EntityCheckboxGridType extends AbstractType
             'y_path',
         ));
 
-        if (version_compare(Kernel::VERSION, '2.6.0', '>=')) {
+        // OptionsResolver 2.6+
+        if (method_exists($resolver, 'setNormalizer')) {
             $resolver->setNormalizer('em', $this->getEntityManagerNormalizer());
         } else {
             $resolver->setNormalizers(array(

--- a/Form/Type/EntityCheckboxGridType.php
+++ b/Form/Type/EntityCheckboxGridType.php
@@ -13,6 +13,7 @@ use Doctrine\Common\Persistence\ManagerRegistry;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\EntityChoiceList;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\ORMQueryBuilderLoader;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -41,23 +42,6 @@ class EntityCheckboxGridType extends AbstractType
     }
 
     public function configureOptions(OptionsResolver $resolver)
-    {
-        $this->internalConfigureOptions($resolver);
-        
-        $resolver->setNormalizer('em', $this->getEntityManagerNormalizer());
-    }
-
-    // BC for SF < 2.7
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
-    {
-        $this->internalConfigureOptions($resolver);
-        
-        $resolver->setNormalizers(array(
-            'em' => $this->getEntityManagerNormalizer(),
-        ));
-    }
-    
-    private function internalConfigureOptions(OptionsResolver $resolver)
     {
         // X Axis defaults
         $defaultXClass = function (Options $options) {
@@ -130,6 +114,20 @@ class EntityCheckboxGridType extends AbstractType
             'x_path',
             'y_path',
         ));
+
+        if (version_compare(Kernel::VERSION, '2.6.0', '>=')) {
+            $resolver->setNormalizer('em', $this->getEntityManagerNormalizer());
+        } else {
+            $resolver->setNormalizers(array(
+                'em' => $this->getEntityManagerNormalizer(),
+            ));
+        }
+    }
+
+    // BC for SF < 2.7
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
     }
     
     private function getEntityManagerNormalizer()

--- a/Form/Type/PolyCollectionType.php
+++ b/Form/Type/PolyCollectionType.php
@@ -159,7 +159,8 @@ class PolyCollectionType extends AbstractType
             'types'
         ));
         
-        if (version_compare(Kernel::VERSION, '2.6.0', '>=')) {
+        // OptionsResolver 2.6+
+        if (method_exists($resolver, 'setNormalizer')) {
             $resolver->setAllowedTypes('types', 'array');
             $resolver->setNormalizer('options', $this->getOptionsNormalizer());
         } else {

--- a/Form/Type/PolyCollectionType.php
+++ b/Form/Type/PolyCollectionType.php
@@ -15,6 +15,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -145,38 +146,6 @@ class PolyCollectionType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $this->internalConfigureOptions($resolver);
-        
-        $resolver->setAllowedTypes('types', 'array');
-        
-        $resolver->setNormalizer('options', $this->getOptionsNormalizer());
-    }
-    
-    // BC for SF < 2.7
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
-    {
-        $this->internalConfigureOptions($resolver);
-        
-        $resolver->setAllowedTypes(array(
-            'types' => 'array'
-        ));
-        
-        $resolver->setNormalizers(array(
-            'options' => $this->getOptionsNormalizer(),
-        ));
-    }
-    
-    private function getOptionsNormalizer()
-    {
-        return function (Options $options, $value) {
-            $value['block_name'] = 'entry';
-
-            return $value;
-        };
-    }
-    
-    private function internalConfigureOptions(OptionsResolverInterface $resolver)
-    {
         $resolver->setDefaults(array(
             'allow_add'      => false,
             'allow_delete'   => false,
@@ -189,5 +158,32 @@ class PolyCollectionType extends AbstractType
         $resolver->setRequired(array(
             'types'
         ));
+        
+        if (version_compare(Kernel::VERSION, '2.6.0', '>=')) {
+            $resolver->setAllowedTypes('types', 'array');
+            $resolver->setNormalizer('options', $this->getOptionsNormalizer());
+        } else {
+            $resolver->setAllowedTypes(array(
+                'types' => 'array'
+            ));
+            $resolver->setNormalizers(array(
+                'options' => $this->getOptionsNormalizer(),
+            ));
+        }
+    }
+    
+    // BC for SF < 2.7
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+    
+    private function getOptionsNormalizer()
+    {
+        return function (Options $options, $value) {
+            $value['block_name'] = 'entry';
+
+            return $value;
+        };
     }
 }


### PR DESCRIPTION
We still had deprecations for `setAllowedTypes` and `setNormalizers` (since SF 2.6), because `setDefaultOptions` still gets called.

So I removed the `internalConfigureOptions` and did the version switching inside `configureOptions` via `version_compare`.

This issue got noted in https://github.com/infinite-networks/InfiniteFormBundle/pull/28#discussion_r32807377. Thanks @stof.

