### PR TITLE
Fix the BC layer for the factory service configuration

### DIFF
--- a/DependencyInjection/InfiniteFormExtension.php
+++ b/DependencyInjection/InfiniteFormExtension.php
@@ -31,6 +31,15 @@ class InfiniteFormExtension extends Extension
 
         if ($configs['attachment']) {
             $loader->load('attachment.xml');
+
+            $attachmentDefinition = $container->getDefinition('infinite_form.attachment.doctrine_manager');
+
+            if (method_exists($attachmentDefinition, 'setFactory')) {
+                $attachmentDefinition->setFactory(array(new Reference('doctrine'), 'getManager'));
+            } else {
+                $attachmentDefinition->setFactoryService('doctrine');
+                $attachmentDefinition->setFactoryMethod('getManager');
+            }
         }
 
         if ($configs['checkbox_grid']) {
@@ -47,15 +56,6 @@ class InfiniteFormExtension extends Extension
 
         if ($configs['twig']) {
             $loader->load('twig.xml');
-        }
-
-        $attachmentDefinition = $container->getDefinition('infinite_form.attachment.form_type');
-
-        if (method_exists($attachmentDefinition, 'setFactory')) {
-            $attachmentDefinition->setFactory(array(new Reference('doctrine'), 'getManager'));
-        } else {
-            $attachmentDefinition->setFactoryService('doctrine');
-            $attachmentDefinition->setFactoryMethod('getManager');
         }
     }
 }

--- a/Resources/config/attachment.xml
+++ b/Resources/config/attachment.xml
@@ -41,16 +41,16 @@
 
         <service id="infinite_form.attachment.form_type" class="%infinite_form.attachment.attachment_type.class%">
             <argument>%infinite_form.attachment.default_secret%</argument>
-            <argument type="service">
-                <service class="Doctrine\Common\Persistence\ObjectManager" public="false">
-                    <!-- Added in extension class -->
-                    <!--<factory service="doctrine" method="getManager"/>-->
-                    <argument>%infinite_form.attachment.entity_manager%</argument>
-                </service>
-            </argument>
+            <argument type="service" id="infinite_form.attachment.doctrine_manager" />
             <argument type="service" id="infinite_form.attachment.path_helper" />
             <argument type="service" id="infinite_form.attachment.uploader" />
             <tag name="form.type" alias="infinite_form_attachment" />
+        </service>
+
+        <service id="infinite_form.attachment.doctrine_manager" class="Doctrine\Common\Persistence\ObjectManager" public="false">
+            <!-- Added in extension class -->
+            <!--<factory service="doctrine" method="getManager"/>-->
+            <argument>%infinite_form.attachment.entity_manager%</argument>
         </service>
     </services>
 

--- a/Tests/DependencyInjection/ExtensionTest.php
+++ b/Tests/DependencyInjection/ExtensionTest.php
@@ -17,7 +17,7 @@ class InfiniteFormExtensionTest extends \PHPUnit_Framework_TestCase
     /**
      * @var ContainerBuilder
      */
-    protected $configuration;
+    protected $container;
 
     /**
      * @var InfiniteFormExtension
@@ -26,30 +26,47 @@ class InfiniteFormExtensionTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->configuration = new ContainerBuilder;
-        $this->extension     = new InfiniteFormExtension;
+        $this->container = new ContainerBuilder;
+        $this->extension = new InfiniteFormExtension;
     }
 
-    public function testPolyCollectionLoaded()
+    public function provideFeatures()
     {
-        $config = array(
-            'polycollection' => true
+        return array(
+            array('polycollection', 'infinite_form.polycollection.form_type'),
+            array('attachment', 'infinite_form.attachment.form_type'),
+            array('checkbox_grid', 'infinite_form.form_type.checkbox_grid_type'),
+            array('entity_search', 'infinite_form.entity_search.type'),
+            array('twig', 'infinite_form.twig_extension'),
         );
-
-        $this->extension->load(array($config), $this->configuration);
-
-        $this->assertHasDefinition('infinite_form.polycollection.form_type');
     }
 
-    public function testPolyCollectionNotLoaded()
+    /**
+     * @dataProvider provideFeatures
+     */
+    public function testFeatureLoaded($feature, $serviceId)
     {
         $config = array(
-            'polycollection' => false
+            $feature => true
         );
 
-        $this->extension->load(array($config), $this->configuration);
+        $this->extension->load(array($config), $this->container);
 
-        $this->assertNotHasDefinition('infinite_form.polycollection.form_type');
+        $this->assertHasDefinition($serviceId);
+    }
+
+    /**
+     * @dataProvider provideFeatures
+     */
+    public function testFeatureNotLoaded($feature, $serviceId)
+    {
+        $config = array(
+            $feature => false
+        );
+
+        $this->extension->load(array($config), $this->container);
+
+        $this->assertNotHasDefinition($serviceId);
     }
 
     /**
@@ -57,7 +74,7 @@ class InfiniteFormExtensionTest extends \PHPUnit_Framework_TestCase
      */
     private function assertHasDefinition($id)
     {
-        $this->assertTrue(($this->configuration->hasDefinition($id) ?: $this->configuration->hasAlias($id)));
+        $this->assertTrue($this->container->hasDefinition($id) || $this->container->hasAlias($id));
     }
 
     /**
@@ -65,11 +82,11 @@ class InfiniteFormExtensionTest extends \PHPUnit_Framework_TestCase
      */
     private function assertNotHasDefinition($id)
     {
-        $this->assertFalse(($this->configuration->hasDefinition($id) ?: $this->configuration->hasAlias($id)));
+        $this->assertFalse($this->container->hasDefinition($id) || $this->container->hasAlias($id));
     }
 
     protected function tearDown()
     {
-        unset($this->configuration);
+        $this->container = null;
     }
 }


### PR DESCRIPTION
- the attachment service is not defined when attachments are disabled
- the factory needs to be set on the doctrine manager service, not on the form type

https://github.com/infinite-networks/InfiniteFormBundle/pull/25 was totally broken, which means that 1.0.0 and 1.0.1 releases are unusable.