### PR TITLE
Fix the check for strict deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,15 @@ matrix:
   fast_finish: true
   include:
     - php: 5.3
-      env: deps="low"
+      env: deps="low" SYMFONY_DEPRECATIONS_HELPER=weak
     - php: 5.6
-      env: SYMFONY_VERSION='2.3.*' SYMFONY_DEPRECATIONS_HELPER=strict
+      env: SYMFONY_VERSION='2.3.*'
     - php: 5.6
       env: SYMFONY_VERSION='2.7.*'
 
 env:
   global:
-    - SYMFONY_DEPRECATIONS_HELPER=weak
+    - SYMFONY_DEPRECATIONS_HELPER=strict
 
 before_script:
   - composer self-update


### PR DESCRIPTION
Deprecations should be checked in a strict way for most builds, and be weak only for deps=low. Otherwise, the testsuite is not catching mistakes like the one fixed in #29.

note that the testsuite is failing for now with this change. this is perfectly expected as your bundle is currently *not* compatible with 2.7 without deprecations (contrary to what the changelog is saying) and the testsuite should catch it.