### PR TITLE
Remove usage of the deprecated PropertyAccess builder method

### DIFF
--- a/Form/DataTransformer/CheckboxGridTransformer.php
+++ b/Form/DataTransformer/CheckboxGridTransformer.php
@@ -53,7 +53,7 @@ class CheckboxGridTransformer implements DataTransformerInterface
 
         $vals = array();
 
-        $accessor = PropertyAccess::getPropertyAccessor();
+        $accessor = PropertyAccess::createPropertyAccessor();
 
         foreach ($value as $object) {
             $xChoice = $accessor->getValue($object, $this->xPath);
@@ -81,7 +81,7 @@ class CheckboxGridTransformer implements DataTransformerInterface
         }
 
         $result = array();
-        $accessor = PropertyAccess::getPropertyAccessor();
+        $accessor = PropertyAccess::createPropertyAccessor();
 
         foreach ($value as $yValue => $row) {
             if (!is_array($row)) {

--- a/Form/DataTransformer/EntitySearchTransformer.php
+++ b/Form/DataTransformer/EntitySearchTransformer.php
@@ -47,7 +47,7 @@ class EntitySearchTransformer implements DataTransformerInterface
         $idFieldArray = $om->getClassMetadata($this->class)->getIdentifierFieldNames();
         $this->idField = reset($idFieldArray);
 
-        $this->accessor = PropertyAccess::getPropertyAccessor();
+        $this->accessor = PropertyAccess::createPropertyAccessor();
     }
 
     public function transform($object)


### PR DESCRIPTION
This removes 30 of the remaining deprecations in the testsuite (see #35 for the PR making the testsuite fail for such deprecations)