### PR TITLE
Use configureOptions in form types in test fixtures

### DIFF
--- a/Tests/CheckboxGrid/Type/SalesmanType.php
+++ b/Tests/CheckboxGrid/Type/SalesmanType.php
@@ -4,6 +4,7 @@ namespace Infinite\FormBundle\Tests\CheckboxGrid\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class SalesmanType extends AbstractType
@@ -26,6 +27,12 @@ class SalesmanType extends AbstractType
     }
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        // BC for Symfony 2.6 and older
+        $this->configureOptions($resolver);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Infinite\FormBundle\Tests\CheckboxGrid\Entity\Salesman',

--- a/Tests/PolyCollection/Type/AbstractType.php
+++ b/Tests/PolyCollection/Type/AbstractType.php
@@ -4,6 +4,7 @@ namespace Infinite\FormBundle\Tests\PolyCollection\Type;
 
 use Symfony\Component\Form\AbstractType as BaseType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class AbstractType extends BaseType
@@ -21,6 +22,12 @@ class AbstractType extends BaseType
     }
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        // BC for Symfony 2.6 and older
+        $this->configureOptions($resolver);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class'  => $this->dataClass,


### PR DESCRIPTION
This removes a few more deprecated notices to go toward making #35 mergeable