### PR TITLE
Use Form::submit instead of Form::bind in tests

### DIFF
--- a/Tests/Attachment/AttachmentFieldTest.php
+++ b/Tests/Attachment/AttachmentFieldTest.php
@@ -64,7 +64,7 @@ class AttachmentFieldTest extends DoctrineOrmTestCase
     {
         $form1 = $this->makeAttachmentForm();
 
-        $form1->bind(array(
+        $form1->submit(array(
             'file' => $this->createFooUpload(),
             'removed' => false,
             'meta' => null,
@@ -77,7 +77,7 @@ class AttachmentFieldTest extends DoctrineOrmTestCase
 
         // Verify that the unsaved attachment can be successfully rebuilt from the form's view data
         $form2 = $this->makeAttachmentForm();
-        $form2->bind(array(
+        $form2->submit(array(
             'file' => null,
             'removed' => false,
             'meta' => $view1->children['meta']->vars['value'],
@@ -93,7 +93,7 @@ class AttachmentFieldTest extends DoctrineOrmTestCase
 
         $form = $this->makeAttachmentForm();
         $form->setData($att);
-        $form->bind(array(
+        $form->submit(array(
             'file' => null,
             'removed' => true,
             'meta' => '',
@@ -116,7 +116,7 @@ class AttachmentFieldTest extends DoctrineOrmTestCase
         $view1 = $form1->createView();
 
         $form2 = $this->makeAttachmentForm();
-        $form2->bind(array(
+        $form2->submit(array(
             'file' => null,
             'removed' => false,
             'meta' => $view1->children['meta']->vars['value'],

--- a/Tests/CheckboxGrid/CheckboxGridTest.php
+++ b/Tests/CheckboxGrid/CheckboxGridTest.php
@@ -91,7 +91,7 @@ class CheckboxGridTest extends \PHPUnit_Framework_TestCase
     {
         $form = $this->makeForm(array(), array());
 
-        $form->bind(array(
+        $form->submit(array(
             'satin' => array('beige' => '1'),
             'gloss' => array('yellow' => '1', 'white' => '1'),
             'matte' => array('beige' => '1'),
@@ -153,7 +153,7 @@ class CheckboxGridTest extends \PHPUnit_Framework_TestCase
             'y_path' => 'finish',
         ));
 
-        $form->bind(array(
+        $form->submit(array(
             'satin' => array('white' => '1'),
         ));
 

--- a/Tests/CheckboxGrid/EntityCheckboxGridTest.php
+++ b/Tests/CheckboxGrid/EntityCheckboxGridTest.php
@@ -120,7 +120,7 @@ class EntityCheckboxGridTest extends DoctrineOrmTestCase
 
         $form = $this->factory->create('infinite_form_test_salesman', $salesman);
 
-        $form->bind(array(
+        $form->submit(array(
             'name' => 'John Smith',
             'productAreas' => array(
                 1 => array(1 => '1', 2 => '1'),
@@ -157,7 +157,7 @@ class EntityCheckboxGridTest extends DoctrineOrmTestCase
 
         $form = $this->factory->create('infinite_form_test_salesman', $salesman);
 
-        $form->bind(array(
+        $form->submit(array(
             'name' => 'John Smith',
             'productAreas' => array(
                 2 => array(3 => '1'),

--- a/Tests/EntitySearch/EntitySearchTest.php
+++ b/Tests/EntitySearch/EntitySearchTest.php
@@ -67,7 +67,7 @@ class EntitySearchTest extends DoctrineOrmTestCase
         // This happens if someone types in a name but doesn't click on the Javascript dropdown list.
         $form = $this->makeForm();
 
-        $form->bind(array(
+        $form->submit(array(
             'id' => '',
             'name' => 'avocado',
         ));
@@ -82,7 +82,7 @@ class EntitySearchTest extends DoctrineOrmTestCase
         // This happens if someone clicks on the Javascript dropdown list.
         $form = $this->makeForm();
 
-        $form->bind(array(
+        $form->submit(array(
             'id' => '4',
             'name' => '', // (Ignored by the transformer since the ID is available)
         ));

--- a/Tests/PolyCollection/PolyCollectionTypeTest.php
+++ b/Tests/PolyCollection/PolyCollectionTypeTest.php
@@ -58,7 +58,7 @@ class PolyCollectionTypeTest extends TypeTestCase
             ),
             'allow_add' => true
         ));
-        $form->bind(array(
+        $form->submit(array(
             array(
                 '_type' => 'unknown_type',
                 'text' => 'Green'
@@ -76,7 +76,7 @@ class PolyCollectionTypeTest extends TypeTestCase
                 'second_type'
             ),
         ));
-        $form->bind('invalid_data');
+        $form->submit('invalid_data');
     }
 
     public function testMultipartPropagation()
@@ -102,7 +102,7 @@ class PolyCollectionTypeTest extends TypeTestCase
             ),
             'allow_delete' => true
         ));
-        $form->bind(null);
+        $form->submit(null);
 
         $this->assertCount(0, $form->getData());
     }
@@ -121,7 +121,7 @@ class PolyCollectionTypeTest extends TypeTestCase
         $form->setData(array(
             new AbstractModel('Green'),
         ));
-        $form->bind(array(
+        $form->submit(array(
             array(
                 '_type' => 'abstract_type',
                 'text' => 'Green'
@@ -162,7 +162,7 @@ class PolyCollectionTypeTest extends TypeTestCase
         $form->setData(array(
             new AbstractModel('Green'),
         ));
-        $form->bind(array(
+        $form->submit(array(
             array(
                 '_type_id' => 'abstract_type',
                 'text' => 'Green'
@@ -200,7 +200,7 @@ class PolyCollectionTypeTest extends TypeTestCase
         $form->setData(array(
             new AbstractModel('Green'),
         ));
-        $form->bind(array(
+        $form->submit(array(
             array(
                 '_type' => 'abstract_type',
                 'text' => 'Green'
@@ -235,7 +235,7 @@ class PolyCollectionTypeTest extends TypeTestCase
             new First('Red', 'Car'),
             new Second('Blue', true)
         ));
-        $form->bind(array(
+        $form->submit(array(
             array(
                 '_type' => 'abstract_type',
                 'text' => 'Green'
@@ -274,7 +274,7 @@ class PolyCollectionTypeTest extends TypeTestCase
             new First('Red', 'Car'),
             new Second('Blue', true)
         ));
-        $form->bind(array(
+        $form->submit(array(
             array(
                 '_type' => 'abstract_type',
                 'text' => 'Brown'


### PR DESCRIPTION
Form::bind is deprecated since Symfony 2.2.

Refs #35