### PR TITLE
Add post-insert event hook when adding rows into collections

### DIFF
--- a/Resources/public/js/collections.js
+++ b/Resources/public/js/collections.js
@@ -99,6 +99,10 @@
                     this.$collection.append($row);
                 }
 
+                var addedEvent = this._createEvent('infinite_collection_added');
+                addedEvent.index = this.internalCount - 1;
+                $row.trigger(addedEvent);
+
                 return $row;
             }
         },


### PR DESCRIPTION
It'd be helpful to be able to process post-insert events in jQuery.

This is very similar to #47, except it's event-based, so works if you're not adding programmatically.

This would allow devs to do things like check for empty fields and set default values; setting data in prototypes will overwrite entity data, whereas a data-default-value attribute in the form could be easily added to the form type and thus available to fetch in the prototype. Thus something like this:

``` javascript
$(window).on('infinite_collection_added', function (e) {
    var $targetRow = e.target;
    var index = e.index;
    var id = '#collection_type_associations_' + index + '_field';
    var $input = $(id, $targetRow);
    var value = $input.val();
    var defaultValue = $input.data('default-value');
    if ('' == value) {
        $input.val(defaultValue);
    }
});
```

There's obviously numerous other situations where executing something after an add would be useful. From what I can see, this isn't quite possible with #47 unless you're adding manually/programatically. Hopefully you can see the value in this small change.