### PR TITLE
Fixed Symfony 2.8 deprecations

### DIFF
--- a/Form/EventListener/CheckboxRowCreationListener.php
+++ b/Form/EventListener/CheckboxRowCreationListener.php
@@ -10,6 +10,7 @@
 namespace Infinite\FormBundle\Form\EventListener;
 
 use Infinite\FormBundle\Form\DataTransformer\AnythingToBooleanTransformer;
+use Infinite\FormBundle\Form\Util\LegacyFormUtil;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -60,11 +61,11 @@ class CheckboxRowCreationListener implements EventSubscriberInterface
         foreach ($options['choice_list']->getRemainingViews() as $choice) {
             if (isset($options['cell_filter']) && !$options['cell_filter']($choice->data, $options['row']->data)) {
                 // Blank cell - put a dummy form control here
-                $form->add($choice->value, 'form', array());
+                $form->add($choice->value, LegacyFormUtil::getType('Symfony\Component\Form\Extension\Core\Type\FormType'), array());
             } else {
                 $builder = $this->factory->createNamedBuilder(
                     $choice->value,
-                    'checkbox',
+                    LegacyFormUtil::getType('Symfony\Component\Form\Extension\Core\Type\CheckboxType'),
                     isset($data[$choice->value]),
                     array(
                         'auto_initialize' => false,

--- a/Form/Type/AttachmentType.php
+++ b/Form/Type/AttachmentType.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Persistence\ObjectManager;
 use Infinite\FormBundle\Attachment\Uploader;
 use Infinite\FormBundle\Form\DataTransformer\AttachmentTransformer;
 use Infinite\FormBundle\Attachment\PathHelper;
+use Infinite\FormBundle\Form\Util\LegacyFormUtil;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
@@ -30,9 +31,9 @@ class AttachmentType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('file', 'file', array('required' => $options['required']))
-            ->add('removed', 'hidden')
-            ->add('meta', 'hidden', array('required' => false))
+            ->add('file', LegacyFormUtil::getType('Symfony\Component\Form\Extension\Core\Type\FileType'), array('required' => $options['required']))
+            ->add('removed', LegacyFormUtil::getType('Symfony\Component\Form\Extension\Core\Type\HiddenType'))
+            ->add('meta', LegacyFormUtil::getType('Symfony\Component\Form\Extension\Core\Type\HiddenType'), array('required' => false))
             ->addViewTransformer(new AttachmentTransformer(
                 $options,
                 $this->om,

--- a/Form/Type/AttachmentType.php
+++ b/Form/Type/AttachmentType.php
@@ -53,7 +53,7 @@ class AttachmentType extends AbstractType
         $view->children['meta']->vars['value'] = $view->vars['value']['meta'];
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'infinite_form_attachment';
     }
@@ -70,5 +70,11 @@ class AttachmentType extends AbstractType
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $this->configureOptions($resolver);
+    }
+
+    // BC for SF < 2.8
+    public function getName()
+    {
+        return $this->getBlockPrefix();
     }
 }

--- a/Form/Type/CheckboxGridType.php
+++ b/Form/Type/CheckboxGridType.php
@@ -50,7 +50,7 @@ class CheckboxGridType extends AbstractType
         $view->vars['headers'] = $options['x_choice_list'];
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'infinite_form_checkbox_grid';
     }
@@ -74,5 +74,11 @@ class CheckboxGridType extends AbstractType
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $this->configureOptions($resolver);
+    }
+
+    // BC for SF < 2.8
+    public function getName()
+    {
+        return $this->getBlockPrefix();
     }
 }

--- a/Form/Type/CheckboxGridType.php
+++ b/Form/Type/CheckboxGridType.php
@@ -10,6 +10,7 @@
 namespace Infinite\FormBundle\Form\Type;
 
 use Infinite\FormBundle\Form\DataTransformer\CheckboxGridTransformer;
+use Infinite\FormBundle\Form\Util\LegacyFormUtil;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
@@ -39,7 +40,7 @@ class CheckboxGridType extends AbstractType
                 'row'         => $choice,
             );
 
-            $builder->add($choice->value, 'infinite_form_checkbox_row', $rowOptions);
+            $builder->add($choice->value, LegacyFormUtil::getType('Infinite\FormBundle\Form\Type\CheckboxRowType'), $rowOptions);
         }
 
         $builder->addViewTransformer(new CheckboxGridTransformer($options));

--- a/Form/Type/CheckboxRowType.php
+++ b/Form/Type/CheckboxRowType.php
@@ -30,7 +30,7 @@ class CheckboxRowType extends AbstractType
         $view->vars['label'] = $options['row']->label;
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'infinite_form_checkbox_row';
     }
@@ -48,5 +48,11 @@ class CheckboxRowType extends AbstractType
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $this->configureOptions($resolver);
+    }
+    
+    // BC for SF < 2.8
+    public function getName()
+    {
+        return $this->getBlockPrefix();
     }
 }

--- a/Form/Type/EntityCheckboxGridType.php
+++ b/Form/Type/EntityCheckboxGridType.php
@@ -31,7 +31,7 @@ class EntityCheckboxGridType extends AbstractType
         $this->registry = $registry;
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'infinite_form_entity_checkbox_grid';
     }
@@ -129,6 +129,12 @@ class EntityCheckboxGridType extends AbstractType
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $this->configureOptions($resolver);
+    }
+    
+    // BC for SF < 2.8
+    public function getName()
+    {
+        return $this->getBlockPrefix();
     }
     
     private function getEntityManagerNormalizer()

--- a/Form/Type/EntityCheckboxGridType.php
+++ b/Form/Type/EntityCheckboxGridType.php
@@ -38,7 +38,9 @@ class EntityCheckboxGridType extends AbstractType
 
     public function getParent()
     {
-        return 'infinite_form_checkbox_grid';
+        return method_exists('\Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? '\Infinite\FormBundle\Form\Type\CheckboxGridType'
+            : 'infinite_form_checkbox_grid';  // BC for SF < 2.8
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/Form/Type/EntityCheckboxGridType.php
+++ b/Form/Type/EntityCheckboxGridType.php
@@ -10,6 +10,7 @@
 namespace Infinite\FormBundle\Form\Type;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
+use Infinite\FormBundle\Form\Util\LegacyFormUtil;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\EntityChoiceList;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\ORMQueryBuilderLoader;
 use Symfony\Component\Form\AbstractType;
@@ -38,9 +39,8 @@ class EntityCheckboxGridType extends AbstractType
 
     public function getParent()
     {
-        return method_exists('\Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? '\Infinite\FormBundle\Form\Type\CheckboxGridType'
-            : 'infinite_form_checkbox_grid';  // BC for SF < 2.8
+        // BC for SF < 2.8
+        return LegacyFormUtil::getType('Infinite\FormBundle\Form\Type\CheckboxGridType');
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/Form/Type/EntitySearchType.php
+++ b/Form/Type/EntitySearchType.php
@@ -3,6 +3,7 @@
 namespace Infinite\FormBundle\Form\Type;
 
 use Infinite\FormBundle\Form\DataTransformer\EntitySearchTransformerFactory;
+use Infinite\FormBundle\Form\Util\LegacyFormUtil;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
@@ -25,8 +26,8 @@ class EntitySearchType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('id', 'hidden')
-            ->add('name', 'text', array('required' => $options['required']))
+            ->add('id', LegacyFormUtil::getType('Symfony\Component\Form\Extension\Core\Type\HiddenType'))
+            ->add('name', LegacyFormUtil::getType('Symfony\Component\Form\Extension\Core\Type\TextType'), array('required' => $options['required']))
             ->setAttribute('search_route', $options['search_route'])
             ->addModelTransformer($this->transformerFactory->createFromOptions($options))
         ;

--- a/Form/Type/EntitySearchType.php
+++ b/Form/Type/EntitySearchType.php
@@ -37,6 +37,11 @@ class EntitySearchType extends AbstractType
         $view->vars['search_route'] = $form->getConfig()->getAttribute('search_route');
     }
 
+    public function getBlockPrefix()
+    {
+        return 'infinite_form_entity_search';
+    }
+
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
@@ -57,9 +62,10 @@ class EntitySearchType extends AbstractType
     {
         $this->configureOptions($resolver);
     }
-
+    
+    // BC for SF < 2.8
     public function getName()
     {
-        return 'infinite_form_entity_search';
+        return $this->getBlockPrefix();
     }
 }

--- a/Form/Type/PolyCollectionType.php
+++ b/Form/Type/PolyCollectionType.php
@@ -137,7 +137,7 @@ class PolyCollectionType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'infinite_form_polycollection';
     }
@@ -179,6 +179,12 @@ class PolyCollectionType extends AbstractType
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $this->configureOptions($resolver);
+    }
+
+    // BC for SF < 2.8
+    public function getName()
+    {
+        return $this->getBlockPrefix();
     }
     
     private function getOptionsNormalizer()

--- a/Form/Util/LegacyFormUtil.php
+++ b/Form/Util/LegacyFormUtil.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * (c) Infinite Networks <http://www.infinite.net.au>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Infinite\FormBundle\Form\Util;
+
+use Symfony\Component\Form\FormTypeInterface;
+
+/**
+ * @internal
+ *
+ * @author Thomas Schulz <mail@king2500.net>
+ */
+final class LegacyFormUtil
+{
+    private static $map = array(
+        'Infinite\FormBundle\Form\Type\AttachmentType' => 'infinite_form_attachment',
+        'Infinite\FormBundle\Form\Type\CheckboxGridType' => 'infinite_form_checkbox_grid',
+        'Infinite\FormBundle\Form\Type\CheckboxRowType' => 'infinite_form_checkbox_row',
+        'Infinite\FormBundle\Form\Type\EntityCheckboxGridType' => 'infinite_form_entity_checkbox_grid',
+        'Infinite\FormBundle\Form\Type\EntitySearchType' => 'infinite_form_entity_search',
+        'Infinite\FormBundle\Form\Type\PolyCollectionType' => 'infinite_form_polycollection',
+        'Infinite\FormBundle\Tests\CheckboxGrid\Type\SalesmanType' => 'infinite_form_test_salesman',
+        'Infinite\FormBundle\Tests\PolyCollection\Type\AbstractType' => 'abstract_type',
+        'Infinite\FormBundle\Tests\PolyCollection\Type\FirstType' => 'first_type',
+        'Infinite\FormBundle\Tests\PolyCollection\Type\SecondType' => 'second_type',
+        'Infinite\FormBundle\Tests\PolyCollection\Type\FourthType' => 'fourth_type',
+        'Infinite\FormBundle\Tests\PolyCollection\Type\UnknownType' => 'unknown_type',
+        'Symfony\Component\Form\Extension\Core\Type\FormType' => 'form',
+        'Symfony\Component\Form\Extension\Core\Type\CheckboxType' => 'checkbox',
+        'Symfony\Component\Form\Extension\Core\Type\FileType' => 'file',
+        'Symfony\Component\Form\Extension\Core\Type\HiddenType' => 'hidden',
+        'Symfony\Component\Form\Extension\Core\Type\NumberType' => 'number',
+        'Symfony\Component\Form\Extension\Core\Type\TextType' => 'text',
+    );
+
+    /**
+     * @param string|FormTypeInterface $type
+     * @return string
+     */
+    public static function getType($type)
+    {
+        // Compat for SF 2.8+
+        if (self::isFullClassNameRequired() && $type instanceof FormTypeInterface) {
+            return get_class($type);
+        }
+
+        // BC for SF < 2.8 for internally used types
+        if (!self::isFullClassNameRequired() && isset(self::$map[$type])) {
+            return self::$map[$type];
+        }
+
+        return $type;
+    }
+
+    /**
+     * Compatibility for Symfony 2.8+
+     * Checks whether FQCN is required as type name.
+     *
+     * @return bool
+     */
+    public static function isFullClassNameRequired()
+    {
+        static $fqcnRequired = null;
+
+        if ($fqcnRequired === null) {
+            $fqcnRequired = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix');
+        }
+
+        return $fqcnRequired;
+    }
+
+    private function __construct()
+    {
+    }
+
+    private function __clone()
+    {
+    }
+}

--- a/Tests/Attachment/AttachmentFieldTest.php
+++ b/Tests/Attachment/AttachmentFieldTest.php
@@ -14,6 +14,7 @@ use Infinite\FormBundle\Attachment\PathHelper;
 use Infinite\FormBundle\Attachment\Sanitiser;
 use Infinite\FormBundle\Attachment\Uploader;
 use Infinite\FormBundle\Form\Type\AttachmentType;
+use Infinite\FormBundle\Form\Util\LegacyFormUtil;
 use Infinite\FormBundle\Tests\Attachment\Attachments\StandardAttachment;
 use Infinite\FormBundle\Tests\CheckboxGrid\Entity as TestEntity;
 use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
@@ -128,7 +129,7 @@ class AttachmentFieldTest extends \PHPUnit_Framework_TestCase
 
     private function makeAttachmentForm()
     {
-        return $this->factory->create('infinite_form_attachment', null, array(
+        return $this->factory->create(LegacyFormUtil::getType('Infinite\FormBundle\Form\Type\AttachmentType'), null, array(
             'class' => 'Infinite\\FormBundle\\Tests\\Attachment\\Attachments\\StandardAttachment',
         ));
     }

--- a/Tests/CheckboxGrid/CheckboxGridTest.php
+++ b/Tests/CheckboxGrid/CheckboxGridTest.php
@@ -11,6 +11,7 @@ namespace Infinite\FormBundle\Tests\CheckboxGrid;
 
 use Infinite\FormBundle\Form\Type\CheckboxGridType;
 use Infinite\FormBundle\Form\Type\CheckboxRowType;
+use Infinite\FormBundle\Form\Util\LegacyFormUtil;
 use Infinite\FormBundle\Tests\CheckboxGrid\Model\ColorFinish;
 use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
 use Symfony\Component\Form\Forms;
@@ -32,7 +33,7 @@ class CheckboxGridTest extends \PHPUnit_Framework_TestCase
 
     protected function makeForm($data, $options)
     {
-        return $this->factory->create('infinite_form_checkbox_grid', $data, $options + array(
+        return $this->factory->create(LegacyFormUtil::getType('Infinite\FormBundle\Form\Type\CheckboxGridType'), $data, $options + array(
             'x_choice_list' => new SimpleChoiceList(array(
                 'white' => 'white',
                 'beige' => 'beige',

--- a/Tests/CheckboxGrid/EntityCheckboxGridTest.php
+++ b/Tests/CheckboxGrid/EntityCheckboxGridTest.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\Tools\SchemaTool;
 use Infinite\FormBundle\Form\Type\CheckboxGridType;
 use Infinite\FormBundle\Form\Type\CheckboxRowType;
 use Infinite\FormBundle\Form\Type\EntityCheckboxGridType;
+use Infinite\FormBundle\Form\Util\LegacyFormUtil;
 use Infinite\FormBundle\Tests\CheckboxGrid\Entity as TestEntity;
 use Infinite\FormBundle\Tests\CheckboxGrid\Type\SalesmanType;
 use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
@@ -116,7 +117,7 @@ class EntityCheckboxGridTest extends \PHPUnit_Framework_TestCase
 
         $salesman = new TestEntity\Salesman;
 
-        $form = $this->factory->create('infinite_form_test_salesman', $salesman);
+        $form = $this->factory->create(LegacyFormUtil::getType('Infinite\FormBundle\Tests\CheckboxGrid\Type\SalesmanType'), $salesman);
 
         $form->submit(array(
             'name' => 'John Smith',
@@ -153,7 +154,7 @@ class EntityCheckboxGridTest extends \PHPUnit_Framework_TestCase
         $salesman = new TestEntity\Salesman;
         $salesman->addProductArea($spa);
 
-        $form = $this->factory->create('infinite_form_test_salesman', $salesman);
+        $form = $this->factory->create(LegacyFormUtil::getType('Infinite\FormBundle\Tests\CheckboxGrid\Type\SalesmanType'), $salesman);
 
         $form->submit(array(
             'name' => 'John Smith',
@@ -173,7 +174,7 @@ class EntityCheckboxGridTest extends \PHPUnit_Framework_TestCase
     {
         $this->expectSpa();
 
-        $form = $this->factory->create('infinite_form_test_salesman', null, array(
+        $form = $this->factory->create(LegacyFormUtil::getType('Infinite\FormBundle\Tests\CheckboxGrid\Type\SalesmanType'), null, array(
             'product_area_options' => array(
                 'x_query_builder' => function (EntityRepository $repo) {
                     return $repo->createQueryBuilder('p')
@@ -211,7 +212,7 @@ class EntityCheckboxGridTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('salesman_em'))
             ->will($this->returnValue($this->em));
 
-        $this->factory->create('infinite_form_test_salesman', null, array(
+        $this->factory->create(LegacyFormUtil::getType('Infinite\FormBundle\Tests\CheckboxGrid\Type\SalesmanType'), null, array(
             'product_area_options' => array(
                 'em' => 'salesman_em',
             ),
@@ -231,7 +232,7 @@ class EntityCheckboxGridTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('stdClass'))
             ->will($this->returnValue(null));
 
-        $this->factory->create('infinite_form_entity_checkbox_grid', array(), array(
+        $this->factory->create(LegacyFormUtil::getType('Infinite\FormBundle\Form\Type\EntityCheckboxGridType'), array(), array(
             'class' => 'stdClass',
             'x_path' => 'productSold',
             'y_path' => 'areaServiced',

--- a/Tests/CheckboxGrid/Type/SalesmanType.php
+++ b/Tests/CheckboxGrid/Type/SalesmanType.php
@@ -21,7 +21,7 @@ class SalesmanType extends AbstractType
         ));
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'infinite_form_test_salesman';
     }
@@ -38,5 +38,11 @@ class SalesmanType extends AbstractType
             'data_class' => 'Infinite\FormBundle\Tests\CheckboxGrid\Entity\Salesman',
             'product_area_options' => array(),
         ));
+    }
+
+    // BC for SF < 2.8
+    public function getName()
+    {
+        return $this->getBlockPrefix();
     }
 }

--- a/Tests/CheckboxGrid/Type/SalesmanType.php
+++ b/Tests/CheckboxGrid/Type/SalesmanType.php
@@ -2,6 +2,7 @@
 
 namespace Infinite\FormBundle\Tests\CheckboxGrid\Type;
 
+use Infinite\FormBundle\Form\Util\LegacyFormUtil;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -13,8 +14,8 @@ class SalesmanType extends AbstractType
     {
         $productAreaOptions = $options['product_area_options'];
 
-        $builder->add('name', 'text');
-        $builder->add('productAreas', 'infinite_form_entity_checkbox_grid', $productAreaOptions + array(
+        $builder->add('name', LegacyFormUtil::getType('Symfony\Component\Form\Extension\Core\Type\TextType'));
+        $builder->add('productAreas', LegacyFormUtil::getType('Infinite\FormBundle\Form\Type\EntityCheckboxGridType'), $productAreaOptions + array(
             'class' => 'Infinite\FormBundle\Tests\CheckboxGrid\Entity\SalesmanProductArea',
             'x_path' => 'productSold',
             'y_path' => 'areaServiced',

--- a/Tests/EntitySearch/EntitySearchTest.php
+++ b/Tests/EntitySearch/EntitySearchTest.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\SchemaTool;
 use Infinite\FormBundle\Form\DataTransformer\EntitySearchTransformerFactory;
 use Infinite\FormBundle\Form\Type\EntitySearchType;
+use Infinite\FormBundle\Form\Util\LegacyFormUtil;
 use Infinite\FormBundle\Tests\EntitySearch\Entity\Fruit;
 use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
 use Symfony\Component\Form\Forms;
@@ -102,7 +103,7 @@ class EntitySearchTest extends \PHPUnit_Framework_TestCase
 
     private function makeForm()
     {
-        return $this->factory->createBuilder('infinite_form_entity_search', null, array(
+        return $this->factory->createBuilder(LegacyFormUtil::getType('Infinite\FormBundle\Form\Type\EntitySearchType'), null, array(
             'invalid_message' => 'Item not found',
             'class'           => 'Infinite\\FormBundle\\Tests\\EntitySearch\\Entity\\Fruit',
         ))->getForm();

--- a/Tests/FormExtension/FormExtensionTest.php
+++ b/Tests/FormExtension/FormExtensionTest.php
@@ -9,6 +9,7 @@
 
 namespace Infinite\FormBundle\Tests\FormExtension;
 
+use Infinite\FormBundle\Form\Util\LegacyFormUtil;
 use Infinite\FormBundle\Twig\FormExtension;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormFactory;
@@ -29,11 +30,11 @@ class FormExtensionTest extends \PHPUnit_Framework_TestCase
         $twig = new \Twig_Environment(new \Twig_Loader_Array(array('template' => '{{ form is invalid ? 1 : 0 }}')));
         $twig->addExtension(new FormExtension);
 
-        $formWithError = $this->formFactory->create('text');
+        $formWithError = $this->formFactory->create(LegacyFormUtil::getType('Symfony\Component\Form\Extension\Core\Type\TextType'));
         $formWithError->addError(new FormError('test error'));
         $this->assertEquals('1', $twig->render('template', array('form' => $formWithError->createView())));
 
-        $formWithoutError = $this->formFactory->create('text');
+        $formWithoutError = $this->formFactory->create(LegacyFormUtil::getType('Symfony\Component\Form\Extension\Core\Type\TextType'));
         $this->assertEquals('0', $twig->render('template', array('form' => $formWithoutError->createView())));
     }
 }

--- a/Tests/PolyCollection/PolyCollectionTypeTest.php
+++ b/Tests/PolyCollection/PolyCollectionTypeTest.php
@@ -9,6 +9,7 @@
 
 namespace Infinite\FormBundle\Tests\PolyCollection;
 
+use Infinite\FormBundle\Form\Util\LegacyFormUtil;
 use Infinite\FormBundle\Tests\PolyCollection\Model\AbstractModel;
 use Infinite\FormBundle\Tests\PolyCollection\Model\First;
 use Infinite\FormBundle\Tests\PolyCollection\Model\Second;
@@ -19,12 +20,8 @@ class PolyCollectionTypeTest extends TypeTestCase
 {
     public function testObjectNotCoveredByTypesArray()
     {
-        $form = $this->factory->create('infinite_form_polycollection', null, array(
-            'types' => array(
-                'abstract_type',
-                'first_type',
-                'second_type'
-            ),
+        $form = $this->factory->create($this->getPolyCollectionType(), null, array(
+            'types' => $this->getTestTypes(),
         ));
         $form->setData(array(
             new AbstractModel('Green'),
@@ -35,12 +32,8 @@ class PolyCollectionTypeTest extends TypeTestCase
     public function testInvalidObject()
     {
         $this->setExpectedException('Symfony\\Component\\Form\\Exception\\ExceptionInterface');
-        $form = $this->factory->create('infinite_form_polycollection', null, array(
-            'types' => array(
-                'abstract_type',
-                'first_type',
-                'second_type'
-            ),
+        $form = $this->factory->create($this->getPolyCollectionType(), null, array(
+            'types' => $this->getTestTypes(),
         ));
         $form->setData(array(
             new \stdClass
@@ -50,17 +43,13 @@ class PolyCollectionTypeTest extends TypeTestCase
     public function testInvalidBindType()
     {
         $this->setExpectedException('InvalidArgumentException');
-        $form = $this->factory->create('infinite_form_polycollection', null, array(
-            'types' => array(
-                'abstract_type',
-                'first_type',
-                'second_type'
-            ),
+        $form = $this->factory->create($this->getPolyCollectionType(), null, array(
+            'types' => $this->getTestTypes(),
             'allow_add' => true
         ));
         $form->submit(array(
             array(
-                '_type' => 'unknown_type',
+                '_type' => LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\UnknownType'),
                 'text' => 'Green'
             )
         ));
@@ -69,22 +58,18 @@ class PolyCollectionTypeTest extends TypeTestCase
     public function testBindInvalidData()
     {
         $this->setExpectedException('Symfony\Component\Form\Exception\UnexpectedTypeException');
-        $form = $this->factory->create('infinite_form_polycollection', null, array(
-            'types' => array(
-                'abstract_type',
-                'first_type',
-                'second_type'
-            ),
+        $form = $this->factory->create($this->getPolyCollectionType(), null, array(
+            'types' => $this->getTestTypes(),
         ));
         $form->submit('invalid_data');
     }
 
     public function testMultipartPropagation()
     {
-        $form = $this->factory->create('infinite_form_polycollection', null, array(
+        $form = $this->factory->create($this->getPolyCollectionType(), null, array(
             'types' => array(
-                'abstract_type',
-                'fourth_type'
+                LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\AbstractType'),
+                LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\FourthType')
             ),
             'allow_add' => true
         ));
@@ -94,12 +79,8 @@ class PolyCollectionTypeTest extends TypeTestCase
 
     public function testBindNullEmptiesCollection()
     {
-        $form = $this->factory->create('infinite_form_polycollection', null, array(
-            'types' => array(
-                'abstract_type',
-                'first_type',
-                'second_type'
-            ),
+        $form = $this->factory->create($this->getPolyCollectionType(), null, array(
+            'types' => $this->getTestTypes(),
             'allow_delete' => true
         ));
         $form->submit(null);
@@ -109,12 +90,8 @@ class PolyCollectionTypeTest extends TypeTestCase
 
     public function testResizedUpIfBoundWithExtraDataAndAllowAdd()
     {
-        $form = $this->factory->create('infinite_form_polycollection', null, array(
-            'types' => array(
-                'abstract_type',
-                'first_type',
-                'second_type'
-            ),
+        $form = $this->factory->create($this->getPolyCollectionType(), null, array(
+            'types' => $this->getTestTypes(),
             'allow_add' => true
         ));
 
@@ -123,11 +100,11 @@ class PolyCollectionTypeTest extends TypeTestCase
         ));
         $form->submit(array(
             array(
-                '_type' => 'abstract_type',
+                '_type' => LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\AbstractType'),
                 'text' => 'Green'
             ),
             array(
-                '_type' => 'first_type',
+                '_type' => LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\FirstType'),
                 'text' => 'Red',
                 'text2' => 'Car'
             )
@@ -149,12 +126,8 @@ class PolyCollectionTypeTest extends TypeTestCase
 
     public function testResizedWithCustomTypeField()
     {
-        $form = $this->factory->create('infinite_form_polycollection', null, array(
-            'types' => array(
-                'abstract_type',
-                'first_type',
-                'second_type'
-            ),
+        $form = $this->factory->create($this->getPolyCollectionType(), null, array(
+            'types' => $this->getTestTypes(),
             'type_name' => '_type_id',
             'allow_add' => true
         ));
@@ -164,11 +137,11 @@ class PolyCollectionTypeTest extends TypeTestCase
         ));
         $form->submit(array(
             array(
-                '_type_id' => 'abstract_type',
+                '_type_id' => LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\AbstractType'),
                 'text' => 'Green'
             ),
             array(
-                '_type_id' => 'first_type',
+                '_type_id' => LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\FirstType'),
                 'text' => 'Red',
                 'text2' => 'Car'
             )
@@ -190,23 +163,19 @@ class PolyCollectionTypeTest extends TypeTestCase
 
     public function testNotResizedIfBoundWithExtraData()
     {
-        $form = $this->factory->create('infinite_form_polycollection', null, array(
-            'types' => array(
-                'abstract_type',
-                'first_type',
-                'second_type'
-            ),
+        $form = $this->factory->create($this->getPolyCollectionType(), null, array(
+            'types' => $this->getTestTypes(),
         ));
         $form->setData(array(
             new AbstractModel('Green'),
         ));
         $form->submit(array(
             array(
-                '_type' => 'abstract_type',
+                '_type' => LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\AbstractType'),
                 'text' => 'Green'
             ),
             array(
-                '_type' => 'first_type',
+                '_type' => LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\FirstType'),
                 'text' => 'Red',
                 'text2' => 'Car'
             )
@@ -222,12 +191,8 @@ class PolyCollectionTypeTest extends TypeTestCase
 
     public function testResizedDownIfBoundWithMissingDataAndAllowDelete()
     {
-        $form = $this->factory->create('infinite_form_polycollection', null, array(
-            'types' => array(
-                'abstract_type',
-                'first_type',
-                'second_type'
-            ),
+        $form = $this->factory->create($this->getPolyCollectionType(), null, array(
+            'types' => $this->getTestTypes(),
             'allow_delete' => true
         ));
         $form->setData(array(
@@ -237,11 +202,11 @@ class PolyCollectionTypeTest extends TypeTestCase
         ));
         $form->submit(array(
             0=>array(
-                '_type' => 'abstract_type',
+                '_type' => LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\AbstractType'),
                 'text' => 'Green'
             ),
             2=>array(
-                '_type' => 'second_type',
+                '_type' => LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\SecondType'),
                 'checked' => 'true'
             )
         ));
@@ -261,12 +226,8 @@ class PolyCollectionTypeTest extends TypeTestCase
 
     public function testNotResizedIfBoundWithMissingData()
     {
-        $form = $this->factory->create('infinite_form_polycollection', null, array(
-            'types' => array(
-                'abstract_type',
-                'first_type',
-                'second_type'
-            ),
+        $form = $this->factory->create($this->getPolyCollectionType(), null, array(
+            'types' => $this->getTestTypes(),
         ));
         $form->setData(array(
             new AbstractModel('Green'),
@@ -275,11 +236,11 @@ class PolyCollectionTypeTest extends TypeTestCase
         ));
         $form->submit(array(
             array(
-                '_type' => 'abstract_type',
+                '_type' => LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\AbstractType'),
                 'text' => 'Brown'
             ),
             array(
-                '_type' => 'first_type',
+                '_type' => LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\FirstType'),
                 'text' => 'Yellow',
                 'text2' => 'Bicycle'
             )
@@ -297,12 +258,8 @@ class PolyCollectionTypeTest extends TypeTestCase
 
     public function testSetDataAdjustsSize()
     {
-        $form = $this->factory->create('infinite_form_polycollection', null, array(
-            'types' => array(
-                'abstract_type',
-                'first_type',
-                'second_type'
-            ),
+        $form = $this->factory->create($this->getPolyCollectionType(), null, array(
+            'types' => $this->getTestTypes(),
             'options' => array(
                 'max_length' => 20,
             )
@@ -354,14 +311,10 @@ class PolyCollectionTypeTest extends TypeTestCase
 
     public function testResizedDownIfBoundWithMissingDataAndAllowDeleteWithEntityIndexProperty()
     {
-        $form = $this->factory->create('infinite_form_polycollection', null, array(
-                'types' => array(
-                    'abstract_type',
-                    'first_type',
-                    'second_type'
-                ),
-                'allow_delete' => true,
-                'index_property' => 'id'
+        $form = $this->factory->create($this->getPolyCollectionType(), null, array(
+            'types' => $this->getTestTypes(),
+            'allow_delete' => true,
+            'index_property' => 'id'
             ));
         $form->setData(array(
                 new AbstractModel('Green', 1),
@@ -370,12 +323,12 @@ class PolyCollectionTypeTest extends TypeTestCase
             ));
         $form->bind(array(
                 array(
-                    '_type' => 'abstract_type',
+                    '_type' => LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\AbstractType'),
                     'text' => 'Green',
                     'id'=>1
                 ),
                 array(
-                    '_type' => 'second_type',
+                    '_type' => LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\SecondType'),
                     'checked' => 'true',
                     'id'=>3
                 )
@@ -396,26 +349,22 @@ class PolyCollectionTypeTest extends TypeTestCase
 
     public function testResizedUpIfBoundWithExtraDataAndAllowAddWithEntityIndexPropertyMissing()
     {
-        $form = $this->factory->create('infinite_form_polycollection', null, array(
-                'types' => array(
-                    'abstract_type',
-                    'first_type',
-                    'second_type'
-                ),
-                'allow_add' => true,
-                'index_property' => 'id'
+        $form = $this->factory->create($this->getPolyCollectionType(), null, array(
+            'types' => $this->getTestTypes(),
+            'allow_add' => true,
+            'index_property' => 'id'
             ));
         $form->setData(array(
                 new AbstractModel('Green', 1),
             ));
         $form->bind(array(
                 array(
-                    '_type' => 'abstract_type',
+                    '_type' => LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\AbstractType'),
                     'text' => 'Green',
                     'id'=>1
                 ),
                 array(
-                    '_type' => 'second_type',
+                    '_type' => LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\SecondType'),
                     'text' => 'Blue',
                     'checked' => 'true'
                 )
@@ -436,14 +385,10 @@ class PolyCollectionTypeTest extends TypeTestCase
 
     public function testReorderedIfBoundWithShuffledDataAndAllowMatchWithEntityIndexProperty()
     {
-        $form = $this->factory->create('infinite_form_polycollection', null, array(
-                'types' => array(
-                    'abstract_type',
-                    'first_type',
-                    'second_type'
-                ),
-                'allow_add' => true,
-                'index_property' => 'id'
+        $form = $this->factory->create($this->getPolyCollectionType(), null, array(
+            'types' => $this->getTestTypes(),
+            'allow_add' => true,
+            'index_property' => 'id'
             ));
         $form->setData(array(
                 new AbstractModel('Green', 1),
@@ -451,12 +396,12 @@ class PolyCollectionTypeTest extends TypeTestCase
             ));
         $form->bind(array(
                 array(
-                    '_type' => 'second_type',
+                    '_type' => LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\SecondType'),
                     'checked' => 'true',
                     'id'=>2
                 ),
                 array(
-                    '_type' => 'abstract_type',
+                    '_type' => LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\AbstractType'),
                     'text' => 'Green',
                     'id'=>1
                 )
@@ -476,7 +421,7 @@ class PolyCollectionTypeTest extends TypeTestCase
 
     public function testContainsNoChildByDefault()
     {
-        $form = $this->factory->create('infinite_form_polycollection', null, array(
+        $form = $this->factory->create($this->getPolyCollectionType(), null, array(
             'types' => array(),
         ));
 
@@ -485,7 +430,7 @@ class PolyCollectionTypeTest extends TypeTestCase
 
     public function testThrowsExceptionIfObjectIsNotTraversable()
     {
-        $form = $this->factory->create('infinite_form_polycollection', null, array(
+        $form = $this->factory->create($this->getPolyCollectionType(), null, array(
             'types' => array(),
         ));
         $this->setExpectedException('Symfony\Component\Form\Exception\UnexpectedTypeException');
@@ -496,13 +441,27 @@ class PolyCollectionTypeTest extends TypeTestCase
     {
         $this->setExpectedException('Symfony\Component\OptionsResolver\Exception\MissingOptionsException');
 
-        $this->factory->create('infinite_form_polycollection', null, array());
+        $this->factory->create($this->getPolyCollectionType(), null, array());
     }
 
     protected function getExtensions()
     {
         return array(
             new FormExtension()
+        );
+    }
+
+    private function getPolyCollectionType()
+    {
+        return LegacyFormUtil::getType('Infinite\FormBundle\Form\Type\PolyCollectionType');
+    }
+
+    private function getTestTypes()
+    {
+        return array(
+            LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\AbstractType'),
+            LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\FirstType'),
+            LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\SecondType'),
         );
     }
 }

--- a/Tests/PolyCollection/Type/AbstractType.php
+++ b/Tests/PolyCollection/Type/AbstractType.php
@@ -38,8 +38,14 @@ class AbstractType extends BaseType
         ));
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'abstract_type';
+    }
+
+    // BC for SF < 2.8
+    public function getName()
+    {
+        return $this->getBlockPrefix();
     }
 }

--- a/Tests/PolyCollection/Type/AbstractType.php
+++ b/Tests/PolyCollection/Type/AbstractType.php
@@ -2,6 +2,7 @@
 
 namespace Infinite\FormBundle\Tests\PolyCollection\Type;
 
+use Infinite\FormBundle\Form\Util\LegacyFormUtil;
 use Symfony\Component\Form\AbstractType as BaseType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -13,11 +14,11 @@ class AbstractType extends BaseType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('id', 'number');
+        $builder->add('id', LegacyFormUtil::getType('Symfony\Component\Form\Extension\Core\Type\NumberType'));
 
-        $builder->add('text', 'text');
+        $builder->add('text', LegacyFormUtil::getType('Symfony\Component\Form\Extension\Core\Type\TextType'));
 
-        $builder->add('_type', 'hidden', array(
+        $builder->add('_type', LegacyFormUtil::getType('Symfony\Component\Form\Extension\Core\Type\HiddenType'), array(
             'data'   => $this->getName(),
             'mapped' => false
         ));

--- a/Tests/PolyCollection/Type/FirstType.php
+++ b/Tests/PolyCollection/Type/FirstType.php
@@ -2,6 +2,7 @@
 
 namespace Infinite\FormBundle\Tests\PolyCollection\Type;
 
+use Infinite\FormBundle\Form\Util\LegacyFormUtil;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class FirstType extends AbstractType
@@ -12,7 +13,7 @@ class FirstType extends AbstractType
     {
         parent::buildForm($builder, $options);
 
-        $builder->add('text2', 'text');
+        $builder->add('text2', LegacyFormUtil::getType('Symfony\Component\Form\Extension\Core\Type\TextType'));
     }
 
     public function getBlockPrefix()

--- a/Tests/PolyCollection/Type/FirstType.php
+++ b/Tests/PolyCollection/Type/FirstType.php
@@ -15,7 +15,7 @@ class FirstType extends AbstractType
         $builder->add('text2', 'text');
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'first_type';
     }

--- a/Tests/PolyCollection/Type/FourthType.php
+++ b/Tests/PolyCollection/Type/FourthType.php
@@ -2,6 +2,7 @@
 
 namespace Infinite\FormBundle\Tests\PolyCollection\Type;
 
+use Infinite\FormBundle\Form\Util\LegacyFormUtil;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class FourthType extends AbstractType
@@ -12,7 +13,7 @@ class FourthType extends AbstractType
     {
         parent::buildForm($builder, $options);
 
-        $builder->add('file', 'file', array('required' => false));
+        $builder->add('file', LegacyFormUtil::getType('Symfony\Component\Form\Extension\Core\Type\FileType'), array('required' => false));
     }
 
     public function getBlockPrefix()

--- a/Tests/PolyCollection/Type/FourthType.php
+++ b/Tests/PolyCollection/Type/FourthType.php
@@ -15,7 +15,7 @@ class FourthType extends AbstractType
         $builder->add('file', 'file', array('required' => false));
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'fourth_type';
     }

--- a/Tests/PolyCollection/Type/SecondType.php
+++ b/Tests/PolyCollection/Type/SecondType.php
@@ -15,7 +15,7 @@ class SecondType extends AbstractType
         $builder->add('checked', 'checkbox', array('required' => false));
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'second_type';
     }

--- a/Tests/PolyCollection/Type/SecondType.php
+++ b/Tests/PolyCollection/Type/SecondType.php
@@ -2,6 +2,7 @@
 
 namespace Infinite\FormBundle\Tests\PolyCollection\Type;
 
+use Infinite\FormBundle\Form\Util\LegacyFormUtil;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class SecondType extends AbstractType
@@ -12,7 +13,7 @@ class SecondType extends AbstractType
     {
         parent::buildForm($builder, $options);
 
-        $builder->add('checked', 'checkbox', array('required' => false));
+        $builder->add('checked', LegacyFormUtil::getType('Symfony\Component\Form\Extension\Core\Type\CheckboxType'), array('required' => false));
     }
 
     public function getBlockPrefix()


### PR DESCRIPTION
See: https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md

* Fixed `FormTypeInterface::getName` deprecations
* Fixed using deprecated form names instead of full-qualified class names  
  Solution for backwards compatibility is similar to what FOSUserBundle did: https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Util/LegacyFormHelper.php
* All changes also applied to the tests.  
  They ran OK on my machine (Win7, PHP 5.6.20, PHPUnit 5.3.2, Sf 2.8.4)