### PR TITLE
Use itemSelector in internalCount initialization

### DIFF
--- a/Resources/public/js/collections.js
+++ b/Resources/public/js/collections.js
@@ -37,10 +37,6 @@
      *                   objects behavior.
      */
     window.infinite.Collection = function (collection, prototypes, options) {
-        this.$collection = $(collection);
-        this.internalCount = this.$collection.children().length;
-        this.$prototypes = prototypes;
-
         this.options = $.extend({
             allowAdd: true,
             allowDelete: true,
@@ -51,6 +47,10 @@
             removeSelector: '.remove_item',
             keepScripts: false
         }, options || {});
+        
+        this.$collection = $(collection);
+        this.internalCount = this.$collection.find(this.options.itemSelector).length;
+        this.$prototypes = prototypes;
 
         this.initialise();
     };


### PR DESCRIPTION
Fixes a bug with an incorrect internalCount when the html does not have collection items as direct children of the collection, i.e:

```html
<table data-form-widget="collection">
    <thead>...</thead>
    <tbody class="items">
        <tr class="item">...</tr>
        <tr class="item">...</tr>
    </tbody>
</table>
```