### PR TITLE
Add "types_options" options (allow to pass specific options to subtypes)

### DIFF
--- a/Form/EventListener/ResizePolyFormListener.php
+++ b/Form/EventListener/ResizePolyFormListener.php
@@ -62,6 +62,11 @@ class ResizePolyFormListener extends ResizeFormListener
     protected $propertyAccessor;
 
     /**
+     * @var bool
+     */
+    protected $useTypesOptions;
+
+    /**
      * @param array<FormInterface> $prototypes
      * @param array $options
      * @param bool $allowAdd
@@ -69,10 +74,11 @@ class ResizePolyFormListener extends ResizeFormListener
      * @param string $typeFieldName
      * @param string $indexProperty
      */
-    public function __construct(array $prototypes, array $options = array(), $allowAdd = false, $allowDelete = false, $typeFieldName = '_type', $indexProperty = null)
+    public function __construct(array $prototypes, array $options = array(), $allowAdd = false, $allowDelete = false, $typeFieldName = '_type', $indexProperty = null, $useTypesOptions = false)
     {
         $this->typeFieldName = $typeFieldName;
         $this->indexProperty = $indexProperty;
+        $this->useTypesOptions = $useTypesOptions;
         $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
         $defaultType = null;
 
@@ -129,6 +135,15 @@ class ResizePolyFormListener extends ResizeFormListener
         return LegacyFormUtil::getType($this->typeMap[$data[$this->typeFieldName]]);
     }
 
+    protected function getOptionsForType($type)
+    {
+        if($this->useTypesOptions === true){
+            return isset($this->options[$type]) ? $this->options[$type] :[] ;
+        }else{
+            return $this->options;
+        }
+    }
+
     public function preSetData(FormEvent $event)
     {
         $form = $event->getForm();
@@ -152,7 +167,7 @@ class ResizePolyFormListener extends ResizeFormListener
             $type = $this->getTypeForObject($value);
             $form->add($name, $type, array_replace(array(
                 'property_path' => '['.$name.']',
-            ), $this->options));
+            ), $this->getOptionsForType($type)));
         }
     }
 
@@ -197,7 +212,7 @@ class ResizePolyFormListener extends ResizeFormListener
                     $type = $this->getTypeForData($item);
                     $form->add($name, $type, array_replace(array(
                         'property_path' => '['.$name.']',
-                    ), $this->options));
+                    ), $this->getOptionsForType($type)));
                 }
 
                 // Add to final data array
@@ -242,7 +257,7 @@ class ResizePolyFormListener extends ResizeFormListener
                         $type = $this->getTypeForData($value);
                         $form->add($name, $type, array_replace(array(
                             'property_path' => '['.$name.']',
-                        ), $this->options));
+                        ), $this->getOptionsForType($type)));
                     }
                 }
             }

--- a/Tests/PolyCollection/PolyCollectionTypeTest.php
+++ b/Tests/PolyCollection/PolyCollectionTypeTest.php
@@ -14,7 +14,10 @@ use Infinite\FormBundle\Tests\PolyCollection\Model\AbstractModel;
 use Infinite\FormBundle\Tests\PolyCollection\Model\First;
 use Infinite\FormBundle\Tests\PolyCollection\Model\Second;
 use Infinite\FormBundle\Tests\PolyCollection\Model\Third;
+use Infinite\FormBundle\Tests\PolyCollection\Type\FirstSpecificOptionsType;
+use Infinite\FormBundle\Tests\PolyCollection\Type\SecondSpecificOptionsType;
 use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\VarDumper\VarDumper;
 
 class PolyCollectionTypeTest extends TypeTestCase
 {
@@ -447,6 +450,48 @@ class PolyCollectionTypeTest extends TypeTestCase
         $this->factory->create($this->getPolyCollectionType(), null, array());
     }
 
+
+    public function testTypeLegacyOptions()
+    {
+        $form = $this->factory->create($this->getPolyCollectionType(), null, array(
+            'types' => $this->getTestTypes(),
+            'options'=>[
+                'max_length'=>'30'
+            ]
+        ));
+        $form->setData(array(
+            new AbstractModel('Green', 1),
+            new Second('Blue', false, 2)
+        ));
+
+        $this->assertEquals(30,$form->get(0)->getConfig()->getOptions()['max_length']);
+        $this->assertEquals(30,$form->get(1)->getConfig()->getOptions()['max_length']);
+    }
+
+    public function testTypesOptions()
+    {
+
+        $form = $this->factory->create($this->getPolyCollectionType(), null, array(
+            'types' => $this->getTestTypesWithSpecificOptions(),
+            'types_options'=>[
+                FirstSpecificOptionsType::class=>[
+                    'first_option'=>888
+                ],
+                SecondSpecificOptionsType::class=>[
+                    'second_option'=>999
+                ]
+            ]
+        ));
+
+        $form->setData(array(
+            new First('Green',false),
+            new Second('Blue', false)
+        ));
+
+        $this->assertEquals(888,$form->get(0)->getConfig()->getOption('first_option'));
+        $this->assertEquals(999,$form->get(1)->getConfig()->getOption('second_option'));
+    }
+
     protected function getExtensions()
     {
         return array(
@@ -465,6 +510,15 @@ class PolyCollectionTypeTest extends TypeTestCase
             LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\AbstractType'),
             LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\FirstType'),
             LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\SecondType'),
+        );
+    }
+
+    private function getTestTypesWithSpecificOptions()
+    {
+        return array(
+            LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\AbstractType'),
+            LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\FirstSpecificOptionsType'),
+            LegacyFormUtil::getType('Infinite\FormBundle\Tests\PolyCollection\Type\SecondSpecificOptionsType'),
         );
     }
 }

--- a/Tests/PolyCollection/Type/FirstSpecificOptionsType.php
+++ b/Tests/PolyCollection/Type/FirstSpecificOptionsType.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: pilou
+ * Date: 09/07/16
+ * Time: 11:05
+ */
+
+namespace Infinite\FormBundle\Tests\PolyCollection\Type;
+
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class FirstSpecificOptionsType extends FirstType
+{
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+        $resolver->setRequired('first_option');
+    }
+
+}

--- a/Tests/PolyCollection/Type/SecondSpecificOptionsType.php
+++ b/Tests/PolyCollection/Type/SecondSpecificOptionsType.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: pilou
+ * Date: 09/07/16
+ * Time: 11:05
+ */
+
+namespace Infinite\FormBundle\Tests\PolyCollection\Type;
+
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class SecondSpecificOptionsType extends SecondType
+{
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+        $resolver->setRequired('second_option');
+    }
+
+}


### PR DESCRIPTION
This PR allows to pass specific form options to subtypes by a new options called "types_options", this is an associative array with "type" as key and an array as value:

```php
$builder->add('resources',PolyCollectionType::class,
            [
                'types' => [
                    ImageResourceFormType::class,
                    LinkResourceFormType::class,
                ],
                'types_options'=>[
                    ImageResourceFormType::class=>[
                        'my_option'=>'hello'
                    ]
                ]
            ]);
```

```php
     // ImageResourceFormType
    public function configureOptions(OptionsResolver $resolver)
    {
        $resolver->setDefaults([
            'data_class'=>ImageResource::class,
            'model_class' => ImageResource::class
        ]);

        $resolver->setRequired('my_option');
    }
```

The "types_options" is used only if it is defined (not empty), otherwhise the default behaviour is used with the "options" key.
