### PR TITLE
Remove deprecated `spaceless` filter

### DIFF
--- a/Resources/views/collection_theme.html.twig
+++ b/Resources/views/collection_theme.html.twig
@@ -14,20 +14,18 @@ of the collection.js helper.
 
 #}
 
-{% block collection_widget %}
-{% apply spaceless %}
+{% block collection_widget -%}
     {% set attr = attr|merge({
         'data-form-widget': 'collection',
     }) %}
     {% if disabled %}
-    {% set attr = attr|merge({
-        'data-disabled': 1
-    }) %}
+        {% set attr = attr|merge({
+            'data-disabled': 1
+        }) %}
     {% endif %}
 
     {{ block('form_widget') }}
     {% if prototype is defined %}
         <a class="btn" data-prototype="{{ form_row(prototype) | escape }}"><i class="icon-plus"></i> Add</a>
     {% endif %}
-{% endapply %}
-{% endblock collection_widget %}
+{%- endblock collection_widget %}


### PR DESCRIPTION
The `spaceless` has been deprecated since Twig 3.12 and can be replaced with whitespace control features like is already used in other templates in this bundle.

https://twig.symfony.com/doc/3.x/filters/spaceless.html#spaceless