### PR TITLE
PHP 8.4. Fix implicit nullable parameter

### DIFF
--- a/Attachment/Streamer.php
+++ b/Attachment/Streamer.php
@@ -39,7 +39,7 @@ class Streamer
         $this->sanitiser = $sanitiser;
     }
 
-    public function stream(AttachmentInterface $attachment, Request $request = null, $disposition = null)
+    public function stream(AttachmentInterface $attachment, ?Request $request = null, $disposition = null)
     {
         $fullPhysicalPath = $this->pathHelper->getFullPath($attachment);
         $mimeType = $this->sanitiser->sanitiseMimeType($attachment->getMimeType());


### PR DESCRIPTION
https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated